### PR TITLE
Fix web network tools import

### DIFF
--- a/lib/helpers/network/network_tasks.dart
+++ b/lib/helpers/network/network_tasks.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get/get.dart' hide Response;
 import 'package:network_info_plus/network_info_plus.dart';
 import 'package:network_tools/network_tools.dart'
-    if (dart.library.html) 'package:bluebubbles/models/html/network_tools.dart';
+    if (dart.library.html) 'package:bluebubbles/database/html/network_tools.dart';
 
 class NetworkTasks {
   static Future<void> onConnect() async {


### PR DESCRIPTION
## Summary
- update the web conditional import for network tasks to point at the HTML-specific network tools shim

## Testing
- `flutter build web` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1598a3088832fa90ce0b9d477ee66