### PR TITLE
Add web shims for ObjectBox query usage

### DIFF
--- a/lib/app/layouts/conversation_list/pages/search/search_view.dart
+++ b/lib/app/layouts/conversation_list/pages/search/search_view.dart
@@ -18,7 +18,8 @@ import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
 import 'package:sliding_up_panel2/sliding_up_panel2.dart';
 import 'package:tuple/tuple.dart';
-import 'package:objectbox/src/native/query/query.dart' as obx;
+import 'package:bluebubbles/database/html/objectbox_query_stub.dart'
+    if (dart.library.io) 'package:objectbox/objectbox.dart' as obx;
 
 class SearchResult {
   final String search;

--- a/lib/database/html/objectbox.dart
+++ b/lib/database/html/objectbox.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: camel_case_types
+import 'dart:async';
+
 import 'package:bluebubbles/database/html/handle.dart';
 
 /// READ: Dummy file to allow objectbox related code to compile on Web. We use
@@ -46,6 +48,28 @@ class Order {
   static const nullsAsZero = 16;
 }
 
+class _Condition {
+  const _Condition();
+
+  _Condition and(_Condition other) => this;
+
+  _Condition or(_Condition other) => this;
+
+  _Condition not() => this;
+}
+
+typedef Condition<T> = _Condition;
+
+class QueryBuilder<T> {
+  QueryBuilder<T> order(dynamic property, {int flags = 0}) => this;
+
+  QueryBuilder<T> link(dynamic relation, [Condition<dynamic>? condition]) => this;
+
+  Query<T> build() => Query<T>();
+
+  Stream<Query<T>> watch({bool triggerImmediately = false}) => const Stream<Query<T>>.empty();
+}
+
 class Box<T> {
   int put(T object, {PutMode mode = PutMode.put}) => throw Exception('Unsupported Platform');
 
@@ -75,7 +99,7 @@ class Box<T> {
 
   bool isEmpty() => throw Exception('Unsupported Platform');
 
-  dynamic query([dynamic qc]) => throw Exception('Unsupported Platform');
+  QueryBuilder<T> query([Condition<T>? qc]) => QueryBuilder<T>();
 }
 
 class ToOne<EntityT> {
@@ -140,29 +164,45 @@ class Query<T> {
   }
 }
 
-class Temp {
+class Temp extends _Condition {
   dynamic add(dynamic thing) {
     return this;
   }
 
-  dynamic equals(dynamic thing) {
-    return this;
+  Condition<dynamic> equals(dynamic thing) {
+    return const _Condition();
   }
 
-  dynamic oneOf(dynamic thing) {
-    return this;
+  Condition<dynamic> oneOf(dynamic thing) {
+    return const _Condition();
   }
 
-  dynamic contains(dynamic thing) {
-    return this;
+  Condition<dynamic> contains(dynamic thing, {bool caseSensitive = true}) {
+    return const _Condition();
   }
 
-  dynamic isNull() {
-    return this;
+  Condition<dynamic> isNull() {
+    return const _Condition();
   }
 
-  dynamic notNull() {
-    return this;
+  Condition<dynamic> notNull() {
+    return const _Condition();
+  }
+
+  Condition<dynamic> greaterOrEqual(dynamic thing) {
+    return const _Condition();
+  }
+
+  Condition<dynamic> greaterThan(dynamic thing) {
+    return const _Condition();
+  }
+
+  Condition<dynamic> lessOrEqual(dynamic thing) {
+    return const _Condition();
+  }
+
+  Condition<dynamic> lessThan(dynamic thing) {
+    return const _Condition();
   }
 }
 

--- a/lib/database/html/objectbox_query_stub.dart
+++ b/lib/database/html/objectbox_query_stub.dart
@@ -1,0 +1,1 @@
+export 'objectbox.dart' show Condition, QueryBuilder;


### PR DESCRIPTION
## Summary
- add lightweight Condition and QueryBuilder shims to the HTML ObjectBox stub so UI query code compiles on web
- expose the shim types through a dedicated stub export for conditional imports
- update the search view to use a conditional ObjectBox import that resolves to the stub on web

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15b2a99ec832f814cb35312ed7021